### PR TITLE
Possibility to pass remote_address for validation-factors 

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -7,6 +7,10 @@ function validationFactors(remote_address) {
   };
 }
 
+function isFunction(obj) {
+  return Object.prototype.toString.call(obj) === "[object Function]";
+}
+
 module.exports.create = function (username, password, remote_address, callback) {
 //  var libxmljs = require('libxmljs');
 //  var payload = new libxmljs.Document();
@@ -17,6 +21,12 @@ module.exports.create = function (username, password, remote_address, callback) 
 //    .node("validation-factor")
 //    .node("name", "remote_address").parent()
 //    .node("value", "127.0.0.1");
+
+  // Maintain backwards compatibility making remote_address optional
+  if (arguments.length == 3 && isFunction(remote_address)) {
+    callback = remote_address;
+    remote_address = undefined;
+  }
 
   var payload = {
     "username": username,
@@ -58,6 +68,12 @@ module.exports.authenticate = function (token, remote_address, callback) {
 //    .node('validation-factor')
 //    .node('name', 'remote_address').parent()
 //    .node('value', '127.0.0.1');
+
+  // Maintain backwards compatibility making remote_address optional
+  if (arguments.length == 2 && isFunction(remote_address)) {
+    callback = remote_address;
+    remote_address = undefined;
+  }
 
   var payload = validationFactors(remote_address);
 


### PR DESCRIPTION
`session.create` and `session.authenticate` should take an (optional) "remote_address" parameter so the caller can pass the real ip of the user to allow SSO with other Crowd backed applications.
