### PR TITLE
Set Content-Length header for DELETE requests for nginx compatibility

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -94,6 +94,12 @@ _doRequest = function (options, callback) {
       return callback(error);
     } 
   }
+  else {
+    if(options.method === "DELETE") {
+      // nginx requires content-length header also for DELETE requests
+      opts.headers['content-length'] = '0';
+    }
+  }
 
   var protocol = (settings.protocol == "https:") ? https : http;
 


### PR DESCRIPTION
If there is nginx in front of the Crowd server, then all DELETE requests fail and never reach Crowd unless the Content-Length header is set. We never have body in those request, so we can unconditionally set it to '0'.

This obviously is a weird requirement from nginx (that apache for example does not have), but not much we can do about it.
