### PR TITLE
Handle response status 204 separately

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -109,6 +109,10 @@ _doRequest = function (options, callback) {
       data += chunk.toString();
     });
   
+    if(response.statusCode === 204) {
+      return callback(null, response.statusCode);
+    }
+
     if(response.statusCode === 401) {
       error = new Error("Application Authorization Error");
       error.type = "APPLICATION_ACCESS_DENIED";


### PR DESCRIPTION
Response without content (status code 204) may or may not contain content-type header, according to HTTP/1.1 specification.

This fixes not returning "Invalid Response from Atlassian Crowd" error when content-type header is missing while deleting Crowd session.
